### PR TITLE
Revert 9ce09e423f24823d52f19ab8247e078977100132

### DIFF
--- a/libc/arch-x86/bionic/syscall.S
+++ b/libc/arch-x86/bionic/syscall.S
@@ -27,25 +27,18 @@ ENTRY(syscall)
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
 
-    # Get and save the system call entry address.
-    call    __kernel_syscall
-    push    %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     # Load all the arguments from the calling frame.
     # (Not all will be valid, depending on the syscall.)
-    mov     24(%esp),%eax
-    mov     28(%esp),%ebx
-    mov     32(%esp),%ecx
-    mov     36(%esp),%edx
-    mov     40(%esp),%esi
-    mov     44(%esp),%edi
-    mov     48(%esp),%ebp
+    mov     20(%esp),%eax
+    mov     24(%esp),%ebx
+    mov     28(%esp),%ecx
+    mov     32(%esp),%edx
+    mov     36(%esp),%esi
+    mov     40(%esp),%edi
+    mov     44(%esp),%ebp
 
     # Make the system call.
-    call    *(%esp)
-    addl    $4, %esp
+    int     $0x80
 
     # Error?
     cmpl    $-MAX_ERRNO, %eax

--- a/libc/arch-x86/syscalls/___clock_nanosleep.S
+++ b/libc/arch-x86/syscalls/___clock_nanosleep.S
@@ -15,20 +15,12 @@ ENTRY(___clock_nanosleep)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_clock_nanosleep, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___close.S
+++ b/libc/arch-x86/syscalls/___close.S
@@ -6,17 +6,9 @@ ENTRY(___close)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_close, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___faccessat.S
+++ b/libc/arch-x86/syscalls/___faccessat.S
@@ -12,19 +12,11 @@ ENTRY(___faccessat)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_faccessat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___fchmod.S
+++ b/libc/arch-x86/syscalls/___fchmod.S
@@ -9,18 +9,10 @@ ENTRY(___fchmod)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_fchmod, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___fchmodat.S
+++ b/libc/arch-x86/syscalls/___fchmodat.S
@@ -12,19 +12,11 @@ ENTRY(___fchmodat)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_fchmodat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___fgetxattr.S
+++ b/libc/arch-x86/syscalls/___fgetxattr.S
@@ -15,20 +15,12 @@ ENTRY(___fgetxattr)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_fgetxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___flistxattr.S
+++ b/libc/arch-x86/syscalls/___flistxattr.S
@@ -12,19 +12,11 @@ ENTRY(___flistxattr)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_flistxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___fsetxattr.S
+++ b/libc/arch-x86/syscalls/___fsetxattr.S
@@ -18,21 +18,13 @@ ENTRY(___fsetxattr)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_fsetxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___mremap.S
+++ b/libc/arch-x86/syscalls/___mremap.S
@@ -18,21 +18,13 @@ ENTRY(___mremap)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_mremap, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/___rt_sigqueueinfo.S
+++ b/libc/arch-x86/syscalls/___rt_sigqueueinfo.S
@@ -12,19 +12,11 @@ ENTRY(___rt_sigqueueinfo)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_rt_sigqueueinfo, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__accept4.S
+++ b/libc/arch-x86/syscalls/__accept4.S
@@ -9,19 +9,11 @@ ENTRY(__accept4)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $18, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__brk.S
+++ b/libc/arch-x86/syscalls/__brk.S
@@ -6,17 +6,9 @@ ENTRY(__brk)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_brk, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__clock_gettime.S
+++ b/libc/arch-x86/syscalls/__clock_gettime.S
@@ -9,18 +9,10 @@ ENTRY(__clock_gettime)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_clock_gettime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__connect.S
+++ b/libc/arch-x86/syscalls/__connect.S
@@ -9,19 +9,11 @@ ENTRY(__connect)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $3, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__epoll_pwait.S
+++ b/libc/arch-x86/syscalls/__epoll_pwait.S
@@ -21,22 +21,14 @@ ENTRY(__epoll_pwait)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_epoll_pwait, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__exit.S
+++ b/libc/arch-x86/syscalls/__exit.S
@@ -6,17 +6,9 @@ ENTRY(__exit)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_exit, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__fadvise64.S
+++ b/libc/arch-x86/syscalls/__fadvise64.S
@@ -21,22 +21,14 @@ ENTRY(__fadvise64)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_fadvise64_64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__fcntl64.S
+++ b/libc/arch-x86/syscalls/__fcntl64.S
@@ -12,19 +12,11 @@ ENTRY(__fcntl64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_fcntl64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__fstatfs64.S
+++ b/libc/arch-x86/syscalls/__fstatfs64.S
@@ -12,19 +12,11 @@ ENTRY(__fstatfs64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_fstatfs64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__getcpu.S
+++ b/libc/arch-x86/syscalls/__getcpu.S
@@ -12,19 +12,11 @@ ENTRY(__getcpu)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_getcpu, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__getcwd.S
+++ b/libc/arch-x86/syscalls/__getcwd.S
@@ -9,18 +9,10 @@ ENTRY(__getcwd)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_getcwd, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__getdents64.S
+++ b/libc/arch-x86/syscalls/__getdents64.S
@@ -12,19 +12,11 @@ ENTRY(__getdents64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_getdents64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__getpid.S
+++ b/libc/arch-x86/syscalls/__getpid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(__getpid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_getpid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__getpriority.S
+++ b/libc/arch-x86/syscalls/__getpriority.S
@@ -9,18 +9,10 @@ ENTRY(__getpriority)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_getpriority, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__gettimeofday.S
+++ b/libc/arch-x86/syscalls/__gettimeofday.S
@@ -9,18 +9,10 @@ ENTRY(__gettimeofday)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_gettimeofday, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__ioctl.S
+++ b/libc/arch-x86/syscalls/__ioctl.S
@@ -12,19 +12,11 @@ ENTRY(__ioctl)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_ioctl, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__llseek.S
+++ b/libc/arch-x86/syscalls/__llseek.S
@@ -18,21 +18,13 @@ ENTRY(__llseek)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR__llseek, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__mmap2.S
+++ b/libc/arch-x86/syscalls/__mmap2.S
@@ -21,22 +21,14 @@ ENTRY(__mmap2)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_mmap2, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__openat.S
+++ b/libc/arch-x86/syscalls/__openat.S
@@ -15,20 +15,12 @@ ENTRY(__openat)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_openat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__ppoll.S
+++ b/libc/arch-x86/syscalls/__ppoll.S
@@ -18,21 +18,13 @@ ENTRY(__ppoll)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_ppoll, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__preadv64.S
+++ b/libc/arch-x86/syscalls/__preadv64.S
@@ -18,21 +18,13 @@ ENTRY(__preadv64)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_preadv, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__pselect6.S
+++ b/libc/arch-x86/syscalls/__pselect6.S
@@ -21,22 +21,14 @@ ENTRY(__pselect6)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_pselect6, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__ptrace.S
+++ b/libc/arch-x86/syscalls/__ptrace.S
@@ -15,20 +15,12 @@ ENTRY(__ptrace)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_ptrace, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__pwritev64.S
+++ b/libc/arch-x86/syscalls/__pwritev64.S
@@ -18,21 +18,13 @@ ENTRY(__pwritev64)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_pwritev, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__reboot.S
+++ b/libc/arch-x86/syscalls/__reboot.S
@@ -15,20 +15,12 @@ ENTRY(__reboot)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_reboot, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__rt_sigaction.S
+++ b/libc/arch-x86/syscalls/__rt_sigaction.S
@@ -15,20 +15,12 @@ ENTRY(__rt_sigaction)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_rt_sigaction, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__rt_sigpending.S
+++ b/libc/arch-x86/syscalls/__rt_sigpending.S
@@ -9,18 +9,10 @@ ENTRY(__rt_sigpending)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_rt_sigpending, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__rt_sigprocmask.S
+++ b/libc/arch-x86/syscalls/__rt_sigprocmask.S
@@ -15,20 +15,12 @@ ENTRY(__rt_sigprocmask)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_rt_sigprocmask, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__rt_sigsuspend.S
+++ b/libc/arch-x86/syscalls/__rt_sigsuspend.S
@@ -9,18 +9,10 @@ ENTRY(__rt_sigsuspend)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_rt_sigsuspend, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__rt_sigtimedwait.S
+++ b/libc/arch-x86/syscalls/__rt_sigtimedwait.S
@@ -15,20 +15,12 @@ ENTRY(__rt_sigtimedwait)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_rt_sigtimedwait, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__sched_getaffinity.S
+++ b/libc/arch-x86/syscalls/__sched_getaffinity.S
@@ -12,19 +12,11 @@ ENTRY(__sched_getaffinity)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_sched_getaffinity, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__set_thread_area.S
+++ b/libc/arch-x86/syscalls/__set_thread_area.S
@@ -6,17 +6,9 @@ ENTRY(__set_thread_area)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_set_thread_area, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__set_tid_address.S
+++ b/libc/arch-x86/syscalls/__set_tid_address.S
@@ -6,17 +6,9 @@ ENTRY(__set_tid_address)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_set_tid_address, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__sigaction.S
+++ b/libc/arch-x86/syscalls/__sigaction.S
@@ -12,19 +12,11 @@ ENTRY(__sigaction)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_sigaction, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__signalfd4.S
+++ b/libc/arch-x86/syscalls/__signalfd4.S
@@ -15,20 +15,12 @@ ENTRY(__signalfd4)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_signalfd4, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__socket.S
+++ b/libc/arch-x86/syscalls/__socket.S
@@ -9,19 +9,11 @@ ENTRY(__socket)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $1, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__statfs64.S
+++ b/libc/arch-x86/syscalls/__statfs64.S
@@ -12,19 +12,11 @@ ENTRY(__statfs64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_statfs64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__timer_create.S
+++ b/libc/arch-x86/syscalls/__timer_create.S
@@ -12,19 +12,11 @@ ENTRY(__timer_create)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_timer_create, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__timer_delete.S
+++ b/libc/arch-x86/syscalls/__timer_delete.S
@@ -6,17 +6,9 @@ ENTRY(__timer_delete)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_timer_delete, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__timer_getoverrun.S
+++ b/libc/arch-x86/syscalls/__timer_getoverrun.S
@@ -6,17 +6,9 @@ ENTRY(__timer_getoverrun)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_timer_getoverrun, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__timer_gettime.S
+++ b/libc/arch-x86/syscalls/__timer_gettime.S
@@ -9,18 +9,10 @@ ENTRY(__timer_gettime)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_timer_gettime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__timer_settime.S
+++ b/libc/arch-x86/syscalls/__timer_settime.S
@@ -15,20 +15,12 @@ ENTRY(__timer_settime)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_timer_settime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/__waitid.S
+++ b/libc/arch-x86/syscalls/__waitid.S
@@ -18,21 +18,13 @@ ENTRY(__waitid)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_waitid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/_exit.S
+++ b/libc/arch-x86/syscalls/_exit.S
@@ -6,17 +6,9 @@ ENTRY(_exit)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_exit_group, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/acct.S
+++ b/libc/arch-x86/syscalls/acct.S
@@ -6,17 +6,9 @@ ENTRY(acct)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_acct, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/adjtimex.S
+++ b/libc/arch-x86/syscalls/adjtimex.S
@@ -6,17 +6,9 @@ ENTRY(adjtimex)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_adjtimex, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/bind.S
+++ b/libc/arch-x86/syscalls/bind.S
@@ -9,19 +9,11 @@ ENTRY(bind)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $2, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/capget.S
+++ b/libc/arch-x86/syscalls/capget.S
@@ -9,18 +9,10 @@ ENTRY(capget)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_capget, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/capset.S
+++ b/libc/arch-x86/syscalls/capset.S
@@ -9,18 +9,10 @@ ENTRY(capset)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_capset, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/chdir.S
+++ b/libc/arch-x86/syscalls/chdir.S
@@ -6,17 +6,9 @@ ENTRY(chdir)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_chdir, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/chroot.S
+++ b/libc/arch-x86/syscalls/chroot.S
@@ -6,17 +6,9 @@ ENTRY(chroot)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_chroot, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/clock_adjtime.S
+++ b/libc/arch-x86/syscalls/clock_adjtime.S
@@ -9,18 +9,10 @@ ENTRY(clock_adjtime)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_clock_adjtime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/clock_getres.S
+++ b/libc/arch-x86/syscalls/clock_getres.S
@@ -9,18 +9,10 @@ ENTRY(clock_getres)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_clock_getres, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/clock_settime.S
+++ b/libc/arch-x86/syscalls/clock_settime.S
@@ -9,18 +9,10 @@ ENTRY(clock_settime)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_clock_settime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/delete_module.S
+++ b/libc/arch-x86/syscalls/delete_module.S
@@ -9,18 +9,10 @@ ENTRY(delete_module)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_delete_module, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/dup.S
+++ b/libc/arch-x86/syscalls/dup.S
@@ -6,17 +6,9 @@ ENTRY(dup)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_dup, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/dup3.S
+++ b/libc/arch-x86/syscalls/dup3.S
@@ -12,19 +12,11 @@ ENTRY(dup3)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_dup3, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/epoll_create1.S
+++ b/libc/arch-x86/syscalls/epoll_create1.S
@@ -6,17 +6,9 @@ ENTRY(epoll_create1)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_epoll_create1, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/epoll_ctl.S
+++ b/libc/arch-x86/syscalls/epoll_ctl.S
@@ -15,20 +15,12 @@ ENTRY(epoll_ctl)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_epoll_ctl, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/eventfd.S
+++ b/libc/arch-x86/syscalls/eventfd.S
@@ -9,18 +9,10 @@ ENTRY(eventfd)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_eventfd2, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/execve.S
+++ b/libc/arch-x86/syscalls/execve.S
@@ -12,19 +12,11 @@ ENTRY(execve)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_execve, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fallocate64.S
+++ b/libc/arch-x86/syscalls/fallocate64.S
@@ -21,22 +21,14 @@ ENTRY(fallocate64)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_fallocate, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fchdir.S
+++ b/libc/arch-x86/syscalls/fchdir.S
@@ -6,17 +6,9 @@ ENTRY(fchdir)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_fchdir, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fchown.S
+++ b/libc/arch-x86/syscalls/fchown.S
@@ -12,19 +12,11 @@ ENTRY(fchown)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_fchown32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fchownat.S
+++ b/libc/arch-x86/syscalls/fchownat.S
@@ -18,21 +18,13 @@ ENTRY(fchownat)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_fchownat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fdatasync.S
+++ b/libc/arch-x86/syscalls/fdatasync.S
@@ -6,17 +6,9 @@ ENTRY(fdatasync)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_fdatasync, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/flock.S
+++ b/libc/arch-x86/syscalls/flock.S
@@ -9,18 +9,10 @@ ENTRY(flock)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_flock, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fremovexattr.S
+++ b/libc/arch-x86/syscalls/fremovexattr.S
@@ -9,18 +9,10 @@ ENTRY(fremovexattr)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_fremovexattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fstat64.S
+++ b/libc/arch-x86/syscalls/fstat64.S
@@ -9,18 +9,10 @@ ENTRY(fstat64)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_fstat64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fstatat64.S
+++ b/libc/arch-x86/syscalls/fstatat64.S
@@ -15,20 +15,12 @@ ENTRY(fstatat64)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_fstatat64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/fsync.S
+++ b/libc/arch-x86/syscalls/fsync.S
@@ -6,17 +6,9 @@ ENTRY(fsync)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_fsync, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/ftruncate64.S
+++ b/libc/arch-x86/syscalls/ftruncate64.S
@@ -12,19 +12,11 @@ ENTRY(ftruncate64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_ftruncate64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getegid.S
+++ b/libc/arch-x86/syscalls/getegid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(getegid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_getegid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/geteuid.S
+++ b/libc/arch-x86/syscalls/geteuid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(geteuid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_geteuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getgid.S
+++ b/libc/arch-x86/syscalls/getgid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(getgid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_getgid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getgroups.S
+++ b/libc/arch-x86/syscalls/getgroups.S
@@ -9,18 +9,10 @@ ENTRY(getgroups)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_getgroups32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getitimer.S
+++ b/libc/arch-x86/syscalls/getitimer.S
@@ -9,18 +9,10 @@ ENTRY(getitimer)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_getitimer, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getpeername.S
+++ b/libc/arch-x86/syscalls/getpeername.S
@@ -9,19 +9,11 @@ ENTRY(getpeername)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $7, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getpgid.S
+++ b/libc/arch-x86/syscalls/getpgid.S
@@ -6,17 +6,9 @@ ENTRY(getpgid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_getpgid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getppid.S
+++ b/libc/arch-x86/syscalls/getppid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(getppid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_getppid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getresgid.S
+++ b/libc/arch-x86/syscalls/getresgid.S
@@ -12,19 +12,11 @@ ENTRY(getresgid)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_getresgid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getresuid.S
+++ b/libc/arch-x86/syscalls/getresuid.S
@@ -12,19 +12,11 @@ ENTRY(getresuid)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_getresuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getrlimit.S
+++ b/libc/arch-x86/syscalls/getrlimit.S
@@ -9,18 +9,10 @@ ENTRY(getrlimit)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_ugetrlimit, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getrusage.S
+++ b/libc/arch-x86/syscalls/getrusage.S
@@ -9,18 +9,10 @@ ENTRY(getrusage)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_getrusage, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getsid.S
+++ b/libc/arch-x86/syscalls/getsid.S
@@ -6,17 +6,9 @@ ENTRY(getsid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_getsid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getsockname.S
+++ b/libc/arch-x86/syscalls/getsockname.S
@@ -9,19 +9,11 @@ ENTRY(getsockname)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $6, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getsockopt.S
+++ b/libc/arch-x86/syscalls/getsockopt.S
@@ -9,19 +9,11 @@ ENTRY(getsockopt)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $15, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getuid.S
+++ b/libc/arch-x86/syscalls/getuid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(getuid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_getuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/getxattr.S
+++ b/libc/arch-x86/syscalls/getxattr.S
@@ -15,20 +15,12 @@ ENTRY(getxattr)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_getxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/init_module.S
+++ b/libc/arch-x86/syscalls/init_module.S
@@ -12,19 +12,11 @@ ENTRY(init_module)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_init_module, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/inotify_add_watch.S
+++ b/libc/arch-x86/syscalls/inotify_add_watch.S
@@ -12,19 +12,11 @@ ENTRY(inotify_add_watch)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_inotify_add_watch, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/inotify_init1.S
+++ b/libc/arch-x86/syscalls/inotify_init1.S
@@ -6,17 +6,9 @@ ENTRY(inotify_init1)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_inotify_init1, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/inotify_rm_watch.S
+++ b/libc/arch-x86/syscalls/inotify_rm_watch.S
@@ -9,18 +9,10 @@ ENTRY(inotify_rm_watch)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_inotify_rm_watch, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/kill.S
+++ b/libc/arch-x86/syscalls/kill.S
@@ -9,18 +9,10 @@ ENTRY(kill)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_kill, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/klogctl.S
+++ b/libc/arch-x86/syscalls/klogctl.S
@@ -12,19 +12,11 @@ ENTRY(klogctl)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_syslog, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/lgetxattr.S
+++ b/libc/arch-x86/syscalls/lgetxattr.S
@@ -15,20 +15,12 @@ ENTRY(lgetxattr)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_lgetxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/linkat.S
+++ b/libc/arch-x86/syscalls/linkat.S
@@ -18,21 +18,13 @@ ENTRY(linkat)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_linkat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/listen.S
+++ b/libc/arch-x86/syscalls/listen.S
@@ -9,19 +9,11 @@ ENTRY(listen)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $4, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/listxattr.S
+++ b/libc/arch-x86/syscalls/listxattr.S
@@ -12,19 +12,11 @@ ENTRY(listxattr)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_listxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/llistxattr.S
+++ b/libc/arch-x86/syscalls/llistxattr.S
@@ -12,19 +12,11 @@ ENTRY(llistxattr)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_llistxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/lremovexattr.S
+++ b/libc/arch-x86/syscalls/lremovexattr.S
@@ -9,18 +9,10 @@ ENTRY(lremovexattr)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_lremovexattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/lseek.S
+++ b/libc/arch-x86/syscalls/lseek.S
@@ -12,19 +12,11 @@ ENTRY(lseek)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_lseek, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/lsetxattr.S
+++ b/libc/arch-x86/syscalls/lsetxattr.S
@@ -18,21 +18,13 @@ ENTRY(lsetxattr)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_lsetxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/madvise.S
+++ b/libc/arch-x86/syscalls/madvise.S
@@ -12,19 +12,11 @@ ENTRY(madvise)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_madvise, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mincore.S
+++ b/libc/arch-x86/syscalls/mincore.S
@@ -12,19 +12,11 @@ ENTRY(mincore)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_mincore, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mkdirat.S
+++ b/libc/arch-x86/syscalls/mkdirat.S
@@ -12,19 +12,11 @@ ENTRY(mkdirat)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_mkdirat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mknodat.S
+++ b/libc/arch-x86/syscalls/mknodat.S
@@ -15,20 +15,12 @@ ENTRY(mknodat)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_mknodat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mlock.S
+++ b/libc/arch-x86/syscalls/mlock.S
@@ -9,18 +9,10 @@ ENTRY(mlock)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_mlock, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mlockall.S
+++ b/libc/arch-x86/syscalls/mlockall.S
@@ -6,17 +6,9 @@ ENTRY(mlockall)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_mlockall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mount.S
+++ b/libc/arch-x86/syscalls/mount.S
@@ -18,21 +18,13 @@ ENTRY(mount)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_mount, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/mprotect.S
+++ b/libc/arch-x86/syscalls/mprotect.S
@@ -12,19 +12,11 @@ ENTRY(mprotect)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_mprotect, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/msync.S
+++ b/libc/arch-x86/syscalls/msync.S
@@ -12,19 +12,11 @@ ENTRY(msync)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_msync, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/munlock.S
+++ b/libc/arch-x86/syscalls/munlock.S
@@ -9,18 +9,10 @@ ENTRY(munlock)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_munlock, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/munlockall.S
+++ b/libc/arch-x86/syscalls/munlockall.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(munlockall)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_munlockall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/munmap.S
+++ b/libc/arch-x86/syscalls/munmap.S
@@ -9,18 +9,10 @@ ENTRY(munmap)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_munmap, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/nanosleep.S
+++ b/libc/arch-x86/syscalls/nanosleep.S
@@ -9,18 +9,10 @@ ENTRY(nanosleep)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_nanosleep, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/personality.S
+++ b/libc/arch-x86/syscalls/personality.S
@@ -6,17 +6,9 @@ ENTRY(personality)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_personality, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/pipe2.S
+++ b/libc/arch-x86/syscalls/pipe2.S
@@ -9,18 +9,10 @@ ENTRY(pipe2)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_pipe2, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/prctl.S
+++ b/libc/arch-x86/syscalls/prctl.S
@@ -18,21 +18,13 @@ ENTRY(prctl)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_prctl, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/pread64.S
+++ b/libc/arch-x86/syscalls/pread64.S
@@ -18,21 +18,13 @@ ENTRY(pread64)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_pread64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/prlimit64.S
+++ b/libc/arch-x86/syscalls/prlimit64.S
@@ -15,20 +15,12 @@ ENTRY(prlimit64)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_prlimit64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/process_vm_readv.S
+++ b/libc/arch-x86/syscalls/process_vm_readv.S
@@ -21,22 +21,14 @@ ENTRY(process_vm_readv)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_process_vm_readv, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/process_vm_writev.S
+++ b/libc/arch-x86/syscalls/process_vm_writev.S
@@ -21,22 +21,14 @@ ENTRY(process_vm_writev)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_process_vm_writev, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/pwrite64.S
+++ b/libc/arch-x86/syscalls/pwrite64.S
@@ -18,21 +18,13 @@ ENTRY(pwrite64)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_pwrite64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/read.S
+++ b/libc/arch-x86/syscalls/read.S
@@ -12,19 +12,11 @@ ENTRY(read)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_read, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/readahead.S
+++ b/libc/arch-x86/syscalls/readahead.S
@@ -15,20 +15,12 @@ ENTRY(readahead)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_readahead, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/readlinkat.S
+++ b/libc/arch-x86/syscalls/readlinkat.S
@@ -15,20 +15,12 @@ ENTRY(readlinkat)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_readlinkat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/readv.S
+++ b/libc/arch-x86/syscalls/readv.S
@@ -12,19 +12,11 @@ ENTRY(readv)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_readv, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/recvfrom.S
+++ b/libc/arch-x86/syscalls/recvfrom.S
@@ -9,19 +9,11 @@ ENTRY(recvfrom)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $12, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/recvmmsg.S
+++ b/libc/arch-x86/syscalls/recvmmsg.S
@@ -9,19 +9,11 @@ ENTRY(recvmmsg)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $19, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/recvmsg.S
+++ b/libc/arch-x86/syscalls/recvmsg.S
@@ -9,19 +9,11 @@ ENTRY(recvmsg)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $17, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/removexattr.S
+++ b/libc/arch-x86/syscalls/removexattr.S
@@ -9,18 +9,10 @@ ENTRY(removexattr)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_removexattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/renameat.S
+++ b/libc/arch-x86/syscalls/renameat.S
@@ -15,20 +15,12 @@ ENTRY(renameat)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_renameat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_get_priority_max.S
+++ b/libc/arch-x86/syscalls/sched_get_priority_max.S
@@ -6,17 +6,9 @@ ENTRY(sched_get_priority_max)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sched_get_priority_max, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_get_priority_min.S
+++ b/libc/arch-x86/syscalls/sched_get_priority_min.S
@@ -6,17 +6,9 @@ ENTRY(sched_get_priority_min)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sched_get_priority_min, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_getparam.S
+++ b/libc/arch-x86/syscalls/sched_getparam.S
@@ -9,18 +9,10 @@ ENTRY(sched_getparam)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_sched_getparam, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_getscheduler.S
+++ b/libc/arch-x86/syscalls/sched_getscheduler.S
@@ -6,17 +6,9 @@ ENTRY(sched_getscheduler)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sched_getscheduler, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_rr_get_interval.S
+++ b/libc/arch-x86/syscalls/sched_rr_get_interval.S
@@ -9,18 +9,10 @@ ENTRY(sched_rr_get_interval)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_sched_rr_get_interval, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_setaffinity.S
+++ b/libc/arch-x86/syscalls/sched_setaffinity.S
@@ -12,19 +12,11 @@ ENTRY(sched_setaffinity)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_sched_setaffinity, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_setparam.S
+++ b/libc/arch-x86/syscalls/sched_setparam.S
@@ -9,18 +9,10 @@ ENTRY(sched_setparam)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_sched_setparam, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_setscheduler.S
+++ b/libc/arch-x86/syscalls/sched_setscheduler.S
@@ -12,19 +12,11 @@ ENTRY(sched_setscheduler)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_sched_setscheduler, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sched_yield.S
+++ b/libc/arch-x86/syscalls/sched_yield.S
@@ -6,17 +6,9 @@ ENTRY(sched_yield)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sched_yield, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sendfile.S
+++ b/libc/arch-x86/syscalls/sendfile.S
@@ -15,20 +15,12 @@ ENTRY(sendfile)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_sendfile, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sendfile64.S
+++ b/libc/arch-x86/syscalls/sendfile64.S
@@ -15,20 +15,12 @@ ENTRY(sendfile64)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_sendfile64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sendmmsg.S
+++ b/libc/arch-x86/syscalls/sendmmsg.S
@@ -9,19 +9,11 @@ ENTRY(sendmmsg)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $20, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sendmsg.S
+++ b/libc/arch-x86/syscalls/sendmsg.S
@@ -9,19 +9,11 @@ ENTRY(sendmsg)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $16, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sendto.S
+++ b/libc/arch-x86/syscalls/sendto.S
@@ -9,19 +9,11 @@ ENTRY(sendto)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $11, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setfsgid.S
+++ b/libc/arch-x86/syscalls/setfsgid.S
@@ -6,17 +6,9 @@ ENTRY(setfsgid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_setfsgid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setfsuid.S
+++ b/libc/arch-x86/syscalls/setfsuid.S
@@ -6,17 +6,9 @@ ENTRY(setfsuid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_setfsuid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setgid.S
+++ b/libc/arch-x86/syscalls/setgid.S
@@ -6,17 +6,9 @@ ENTRY(setgid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_setgid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setgroups.S
+++ b/libc/arch-x86/syscalls/setgroups.S
@@ -9,18 +9,10 @@ ENTRY(setgroups)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setgroups32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sethostname.S
+++ b/libc/arch-x86/syscalls/sethostname.S
@@ -9,18 +9,10 @@ ENTRY(sethostname)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_sethostname, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setitimer.S
+++ b/libc/arch-x86/syscalls/setitimer.S
@@ -12,19 +12,11 @@ ENTRY(setitimer)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_setitimer, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setns.S
+++ b/libc/arch-x86/syscalls/setns.S
@@ -9,18 +9,10 @@ ENTRY(setns)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setns, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setpgid.S
+++ b/libc/arch-x86/syscalls/setpgid.S
@@ -9,18 +9,10 @@ ENTRY(setpgid)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setpgid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setpriority.S
+++ b/libc/arch-x86/syscalls/setpriority.S
@@ -12,19 +12,11 @@ ENTRY(setpriority)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_setpriority, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setregid.S
+++ b/libc/arch-x86/syscalls/setregid.S
@@ -9,18 +9,10 @@ ENTRY(setregid)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setregid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setresgid.S
+++ b/libc/arch-x86/syscalls/setresgid.S
@@ -12,19 +12,11 @@ ENTRY(setresgid)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_setresgid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setresuid.S
+++ b/libc/arch-x86/syscalls/setresuid.S
@@ -12,19 +12,11 @@ ENTRY(setresuid)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_setresuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setreuid.S
+++ b/libc/arch-x86/syscalls/setreuid.S
@@ -9,18 +9,10 @@ ENTRY(setreuid)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setreuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setrlimit.S
+++ b/libc/arch-x86/syscalls/setrlimit.S
@@ -9,18 +9,10 @@ ENTRY(setrlimit)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_setrlimit, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setsid.S
+++ b/libc/arch-x86/syscalls/setsid.S
@@ -3,16 +3,8 @@
 #include <private/bionic_asm.h>
 
 ENTRY(setsid)
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     movl    $__NR_setsid, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setsockopt.S
+++ b/libc/arch-x86/syscalls/setsockopt.S
@@ -9,19 +9,11 @@ ENTRY(setsockopt)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $14, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/settimeofday.S
+++ b/libc/arch-x86/syscalls/settimeofday.S
@@ -9,18 +9,10 @@ ENTRY(settimeofday)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_settimeofday, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setuid.S
+++ b/libc/arch-x86/syscalls/setuid.S
@@ -6,17 +6,9 @@ ENTRY(setuid)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_setuid32, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/setxattr.S
+++ b/libc/arch-x86/syscalls/setxattr.S
@@ -18,21 +18,13 @@ ENTRY(setxattr)
     pushl   %edi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     28(%esp), %ebx
-    mov     32(%esp), %ecx
-    mov     36(%esp), %edx
-    mov     40(%esp), %esi
-    mov     44(%esp), %edi
+    mov     24(%esp), %ebx
+    mov     28(%esp), %ecx
+    mov     32(%esp), %edx
+    mov     36(%esp), %esi
+    mov     40(%esp), %edi
     movl    $__NR_setxattr, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/shutdown.S
+++ b/libc/arch-x86/syscalls/shutdown.S
@@ -9,19 +9,11 @@ ENTRY(shutdown)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $13, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sigaltstack.S
+++ b/libc/arch-x86/syscalls/sigaltstack.S
@@ -9,18 +9,10 @@ ENTRY(sigaltstack)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_sigaltstack, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/socketpair.S
+++ b/libc/arch-x86/syscalls/socketpair.S
@@ -9,19 +9,11 @@ ENTRY(socketpair)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
     mov     $8, %ebx
     mov     %esp, %ecx
-    addl    $16, %ecx
+    addl    $12, %ecx
     movl    $__NR_socketcall, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/splice.S
+++ b/libc/arch-x86/syscalls/splice.S
@@ -21,22 +21,14 @@ ENTRY(splice)
     pushl   %ebp
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ebp, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     32(%esp), %ebx
-    mov     36(%esp), %ecx
-    mov     40(%esp), %edx
-    mov     44(%esp), %esi
-    mov     48(%esp), %edi
-    mov     52(%esp), %ebp
+    mov     28(%esp), %ebx
+    mov     32(%esp), %ecx
+    mov     36(%esp), %edx
+    mov     40(%esp), %esi
+    mov     44(%esp), %edi
+    mov     48(%esp), %ebp
     movl    $__NR_splice, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/swapoff.S
+++ b/libc/arch-x86/syscalls/swapoff.S
@@ -6,17 +6,9 @@ ENTRY(swapoff)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_swapoff, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/swapon.S
+++ b/libc/arch-x86/syscalls/swapon.S
@@ -9,18 +9,10 @@ ENTRY(swapon)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_swapon, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/symlinkat.S
+++ b/libc/arch-x86/syscalls/symlinkat.S
@@ -12,19 +12,11 @@ ENTRY(symlinkat)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_symlinkat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sync.S
+++ b/libc/arch-x86/syscalls/sync.S
@@ -6,17 +6,9 @@ ENTRY(sync)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sync, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/sysinfo.S
+++ b/libc/arch-x86/syscalls/sysinfo.S
@@ -6,17 +6,9 @@ ENTRY(sysinfo)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_sysinfo, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/tee.S
+++ b/libc/arch-x86/syscalls/tee.S
@@ -15,20 +15,12 @@ ENTRY(tee)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_tee, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/tgkill.S
+++ b/libc/arch-x86/syscalls/tgkill.S
@@ -12,19 +12,11 @@ ENTRY(tgkill)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_tgkill, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/timerfd_create.S
+++ b/libc/arch-x86/syscalls/timerfd_create.S
@@ -9,18 +9,10 @@ ENTRY(timerfd_create)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_timerfd_create, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/timerfd_gettime.S
+++ b/libc/arch-x86/syscalls/timerfd_gettime.S
@@ -9,18 +9,10 @@ ENTRY(timerfd_gettime)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_timerfd_gettime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/timerfd_settime.S
+++ b/libc/arch-x86/syscalls/timerfd_settime.S
@@ -15,20 +15,12 @@ ENTRY(timerfd_settime)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_timerfd_settime, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/times.S
+++ b/libc/arch-x86/syscalls/times.S
@@ -6,17 +6,9 @@ ENTRY(times)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_times, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/truncate.S
+++ b/libc/arch-x86/syscalls/truncate.S
@@ -9,18 +9,10 @@ ENTRY(truncate)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_truncate, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/truncate64.S
+++ b/libc/arch-x86/syscalls/truncate64.S
@@ -12,19 +12,11 @@ ENTRY(truncate64)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_truncate64, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/umask.S
+++ b/libc/arch-x86/syscalls/umask.S
@@ -6,17 +6,9 @@ ENTRY(umask)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_umask, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/umount2.S
+++ b/libc/arch-x86/syscalls/umount2.S
@@ -9,18 +9,10 @@ ENTRY(umount2)
     pushl   %ecx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset ecx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     16(%esp), %ebx
-    mov     20(%esp), %ecx
+    mov     12(%esp), %ebx
+    mov     16(%esp), %ecx
     movl    $__NR_umount2, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/uname.S
+++ b/libc/arch-x86/syscalls/uname.S
@@ -6,17 +6,9 @@ ENTRY(uname)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_uname, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/unlinkat.S
+++ b/libc/arch-x86/syscalls/unlinkat.S
@@ -12,19 +12,11 @@ ENTRY(unlinkat)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_unlinkat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/unshare.S
+++ b/libc/arch-x86/syscalls/unshare.S
@@ -6,17 +6,9 @@ ENTRY(unshare)
     pushl   %ebx
     .cfi_def_cfa_offset 8
     .cfi_rel_offset ebx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     12(%esp), %ebx
+    mov     8(%esp), %ebx
     movl    $__NR_unshare, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/utimensat.S
+++ b/libc/arch-x86/syscalls/utimensat.S
@@ -15,20 +15,12 @@ ENTRY(utimensat)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_utimensat, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/vmsplice.S
+++ b/libc/arch-x86/syscalls/vmsplice.S
@@ -15,20 +15,12 @@ ENTRY(vmsplice)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_vmsplice, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/wait4.S
+++ b/libc/arch-x86/syscalls/wait4.S
@@ -15,20 +15,12 @@ ENTRY(wait4)
     pushl   %esi
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset esi, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     24(%esp), %ebx
-    mov     28(%esp), %ecx
-    mov     32(%esp), %edx
-    mov     36(%esp), %esi
+    mov     20(%esp), %ebx
+    mov     24(%esp), %ecx
+    mov     28(%esp), %edx
+    mov     32(%esp), %esi
     movl    $__NR_wait4, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/write.S
+++ b/libc/arch-x86/syscalls/write.S
@@ -12,19 +12,11 @@ ENTRY(write)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_write, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/arch-x86/syscalls/writev.S
+++ b/libc/arch-x86/syscalls/writev.S
@@ -12,19 +12,11 @@ ENTRY(writev)
     pushl   %edx
     .cfi_adjust_cfa_offset 4
     .cfi_rel_offset edx, 0
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-    mov     20(%esp), %ebx
-    mov     24(%esp), %ecx
-    mov     28(%esp), %edx
+    mov     16(%esp), %ebx
+    mov     20(%esp), %ecx
+    mov     24(%esp), %edx
     movl    $__NR_writev, %eax
-    call    *(%esp)
-    addl    $4, %esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %eax
     jb      1f
     negl    %eax

--- a/libc/bionic/__libc_init_main_thread.cpp
+++ b/libc/bionic/__libc_init_main_thread.cpp
@@ -51,9 +51,6 @@ extern "C" int __set_tid_address(int* tid_address);
 
 void __libc_init_main_thread(KernelArgumentBlock& args) {
   __libc_auxv = args.auxv;
-#if defined(__i386__)
-  __libc_init_sysinfo(args);
-#endif
 
   static pthread_internal_t main_thread;
 

--- a/libc/bionic/libc_init_common.cpp
+++ b/libc/bionic/libc_init_common.cpp
@@ -70,23 +70,7 @@ void __libc_init_global_stack_chk_guard(KernelArgumentBlock& args) {
   __stack_chk_guard = *reinterpret_cast<uintptr_t*>(args.getauxval(AT_RANDOM));
 }
 
-#if defined(__i386__)
-__LIBC_HIDDEN__ void* __libc_sysinfo = nullptr;
-
-__LIBC_HIDDEN__ void __libc_init_sysinfo(KernelArgumentBlock& args) {
-  __libc_sysinfo = reinterpret_cast<void*>(args.getauxval(AT_SYSINFO));
-}
-
-// TODO: lose this function and just access __libc_sysinfo directly.
-extern "C" void* __kernel_syscall() {
-  return __libc_sysinfo;
-}
-#endif
-
 void __libc_init_globals(KernelArgumentBlock& args) {
-#if defined(__i386__)
-  __libc_init_sysinfo(args);
-#endif
   // Initialize libc globals that are needed in both the linker and in libc.
   // In dynamic binaries, this is run at least twice for different copies of the
   // globals, once for the linker's copy and once for the one in libc.so.

--- a/libc/private/bionic_globals.h
+++ b/libc/private/bionic_globals.h
@@ -49,9 +49,4 @@ __LIBC_HIDDEN__ void __libc_init_malloc(libc_globals* globals);
 __LIBC_HIDDEN__ void __libc_init_setjmp_cookie(libc_globals* globals, KernelArgumentBlock& args);
 __LIBC_HIDDEN__ void __libc_init_vdso(libc_globals* globals, KernelArgumentBlock& args);
 
-#if defined(__i386__)
-__LIBC_HIDDEN__ extern void* __libc_sysinfo;
-__LIBC_HIDDEN__ void __libc_init_sysinfo(KernelArgumentBlock& args);
-#endif
-
 #endif

--- a/libc/tools/gensyscalls.py
+++ b/libc/tools/gensyscalls.py
@@ -168,20 +168,9 @@ END(%(func)s)
 
 x86_registers = [ "ebx", "ecx", "edx", "esi", "edi", "ebp" ]
 
-x86_call_prepare = """\
-
-    call    __kernel_syscall
-    pushl   %eax
-    .cfi_adjust_cfa_offset 4
-    .cfi_rel_offset eax, 0
-
-"""
-
 x86_call = """\
     movl    $%(__NR_name)s, %%eax
-    call    *(%%esp)
-    addl    $4, %%esp
-
+    int     $0x80
     cmpl    $-MAX_ERRNO, %%eax
     jb      1f
     negl    %%eax
@@ -324,7 +313,7 @@ def x86_genstub(syscall):
     result     = syscall_stub_header % syscall
 
     numparams = count_generic_param_registers(syscall["params"])
-    stack_bias = numparams*4 + 8
+    stack_bias = numparams*4 + 4
     offset = 0
     mov_result = ""
     first_push = True
@@ -340,7 +329,6 @@ def x86_genstub(syscall):
         mov_result += "    mov     %d(%%esp), %%%s\n" % (stack_bias+offset, register)
         offset += 4
 
-    result += x86_call_prepare
     result += mov_result
     result += x86_call % syscall
 
@@ -366,9 +354,7 @@ def x86_genstub_socketcall(syscall):
     result += "    pushl   %ecx\n"
     result += "    .cfi_adjust_cfa_offset 4\n"
     result += "    .cfi_rel_offset ecx, 0\n"
-    stack_bias = 16
-
-    result += x86_call_prepare
+    stack_bias = 12
 
     # set the call id (%ebx)
     result += "    mov     $%d, %%ebx\n" % syscall["socketcall_id"]

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -44,7 +44,6 @@
 #include <vector>
 
 // Private C library headers.
-#include "private/bionic_globals.h"
 #include "private/bionic_tls.h"
 #include "private/KernelArgumentBlock.h"
 #include "private/ScopedPthreadMutexLocker.h"
@@ -69,8 +68,6 @@
 
 extern void __libc_init_globals(KernelArgumentBlock&);
 extern void __libc_init_AT_SECURE(KernelArgumentBlock&);
-
-extern "C" void _start();
 
 // Override macros to use C++ style casts.
 #undef ELF_ST_TYPE
@@ -4163,9 +4160,10 @@ bool soinfo::link_image(const soinfo_list_t& global_group, const soinfo_list_t& 
   }
 #endif
 
-  // We can also turn on GNU RELRO protection if we're not linking the dynamic linker
-  // itself --- it can't make system calls yet, and will have to call protect_relro later.
-  if (!is_linker() && !protect_relro()) {
+  /* We can also turn on GNU RELRO protection */
+  if (phdr_table_protect_gnu_relro(phdr, phnum, load_bias) < 0) {
+    DL_ERR("can't enable GNU RELRO protection for \"%s\": %s",
+           get_realpath(), strerror(errno));
     return false;
   }
 
@@ -4187,15 +4185,6 @@ bool soinfo::link_image(const soinfo_list_t& global_group, const soinfo_list_t& 
   }
 
   notify_gdb_of_load(this);
-  return true;
-}
-
-bool soinfo::protect_relro() {
-  if (phdr_table_protect_gnu_relro(phdr, phnum, load_bias) < 0) {
-    DL_ERR("can't enable GNU RELRO protection for \"%s\": %s",
-           get_realpath(), strerror(errno));
-    return false;
-  }
   return true;
 }
 
@@ -4542,9 +4531,8 @@ static ElfW(Addr) get_elf_exec_load_bias(const ElfW(Ehdr)* elf) {
   return 0;
 }
 
-static void __linker_cannot_link(KernelArgumentBlock& args) {
-  __libc_fatal("CANNOT LINK EXECUTABLE \"%s\": %s", args.argv[0], linker_get_error_buffer());
-}
+extern "C" int __set_tls(void*);
+extern "C" void _start();
 
 /*
  * This is the entry point for the linker, called from begin.S. This
@@ -4557,6 +4545,9 @@ static void __linker_cannot_link(KernelArgumentBlock& args) {
  */
 extern "C" ElfW(Addr) __linker_init(void* raw_args) {
   KernelArgumentBlock args(raw_args);
+
+  void* tls[BIONIC_TLS_SLOTS];
+  __set_tls(tls);
 
   ElfW(Addr) linker_addr = args.getauxval(AT_BASE);
   ElfW(Addr) entry_point = args.getauxval(AT_ENTRY);
@@ -4586,32 +4577,17 @@ extern "C" ElfW(Addr) __linker_init(void* raw_args) {
   linker_so.phnum = elf_hdr->e_phnum;
   linker_so.set_linker_flag();
 
-  // Prelink the linker so we can access linker globals.
-  if (!linker_so.prelink_image()) __linker_cannot_link(args);
-
   // This might not be obvious... The reasons why we pass g_empty_list
   // in place of local_group here are (1) we do not really need it, because
   // linker is built with DT_SYMBOLIC and therefore relocates its symbols against
   // itself without having to look into local_group and (2) allocators
   // are not yet initialized, and therefore we cannot use linked_list.push_*
   // functions at this point.
-  if (!linker_so.link_image(g_empty_list, g_empty_list, nullptr)) __linker_cannot_link(args);
+  if (!(linker_so.prelink_image() && linker_so.link_image(g_empty_list, g_empty_list, nullptr))) {
+    __libc_fatal("CANNOT LINK EXECUTABLE \"%s\": %s", args.argv[0], linker_get_error_buffer());
+  }
 
-#if defined(__i386__)
-  // On x86, we can't make system calls before this point.
-  // We can't move this up because this needs to assign to a global.
-  // Note that until we call __libc_init_main_thread below we have
-  // no TLS, so you shouldn't make a system call that can fail, because
-  // it will SEGV when it tries to set errno.
-  __libc_init_sysinfo(args);
-#endif
-
-  // Initialize the main thread (including TLS, so system calls really work).
   __libc_init_main_thread(args);
-
-  // We didn't protect the linker's RELRO pages in link_image because we
-  // couldn't make system calls on x86 at that point, but we can now...
-  if (!linker_so.protect_relro()) __linker_cannot_link(args);
 
   // Initialize the linker's static libc's globals
   __libc_init_globals(args);

--- a/linker/linker.h
+++ b/linker/linker.h
@@ -291,7 +291,6 @@ struct soinfo {
   bool prelink_image();
   bool link_image(const soinfo_list_t& global_group, const soinfo_list_t& local_group,
                   const android_dlextinfo* extinfo);
-  bool protect_relro();
 
   void add_child(soinfo* child);
   void remove_all_links();


### PR DESCRIPTION
That commit is supposed to optimize some system calls on x86, but
instead causes crashes (maybe latest hardware is not affected).