### PR TITLE
Fix TLS slots for x86

### DIFF
--- a/libc/private/bionic_tls.h
+++ b/libc/private/bionic_tls.h
@@ -51,21 +51,22 @@ __BEGIN_DECLS
 enum {
   TLS_SLOT_SELF = 0, // The kernel requires this specific slot for x86.
   TLS_SLOT_THREAD_ID,
-  TLS_SLOT_ERRNO = 5,
+
+  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
+  
+  TLS_SLOT_ERRNO,
 
   // These two aren't used by bionic itself, but allow the graphics code to
   // access TLS directly rather than using the pthread API.
-  TLS_SLOT_OPENGL_API = 6,
-  TLS_SLOT_OPENGL = 7,
+  TLS_SLOT_OPENGL_API,
+  TLS_SLOT_OPENGL,
+  TLS_SLOT_DLERROR,
 
   // This slot is only used to pass information from the dynamic linker to
   // libc.so when the C library is loaded in to memory. The C runtime init
   // function will then clear it. Since its use is extremely temporary,
   // we reuse an existing location that isn't needed during libc startup.
   TLS_SLOT_BIONIC_PREINIT = TLS_SLOT_OPENGL_API,
-
-  TLS_SLOT_STACK_GUARD = 8, // GCC requires this specific slot for x86.
-  TLS_SLOT_DLERROR,
 
   // Fast storage for Thread::Current() in ART.
   TLS_SLOT_ART_THREAD_SELF,


### PR DESCRIPTION
Aligns with this libhybris patch:
https://github.com/libhybris/libhybris/pull/370