### PR TITLE
Upstream changes necessary for devices with /odm partitions

### DIFF
--- a/libc/include/paths.h
+++ b/libc/include/paths.h
@@ -35,7 +35,7 @@
 #define	_PATH_BSHELL	"/system/bin/sh"
 #define	_PATH_BSHELL2	"/sbin/sh"
 #define	_PATH_CONSOLE	"/dev/console"
-#define	_PATH_DEFPATH	"/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin"
+#define	_PATH_DEFPATH	"/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin:/vendor/xbin"
 #define	_PATH_DEV	"/dev/"
 #define	_PATH_DEVNULL	"/dev/null"
 #define	_PATH_KLOG	"/proc/kmsg"

--- a/libc/include/paths.h
+++ b/libc/include/paths.h
@@ -35,7 +35,7 @@
 #define	_PATH_BSHELL	"/system/bin/sh"
 #define	_PATH_BSHELL2	"/sbin/sh"
 #define	_PATH_CONSOLE	"/dev/console"
-#define	_PATH_DEFPATH	"/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin:/vendor/xbin"
+#define	_PATH_DEFPATH	"/sbin:/system/sbin:/system/bin:/system/xbin:/vendor/bin:/vendor/xbin"
 #define	_PATH_DEV	"/dev/"
 #define	_PATH_DEVNULL	"/dev/null"
 #define	_PATH_KLOG	"/proc/kmsg"

--- a/libc/include/paths.h
+++ b/libc/include/paths.h
@@ -35,7 +35,7 @@
 #define	_PATH_BSHELL	"/system/bin/sh"
 #define	_PATH_BSHELL2	"/sbin/sh"
 #define	_PATH_CONSOLE	"/dev/console"
-#define	_PATH_DEFPATH	"/sbin:/system/sbin:/system/bin:/system/xbin:/vendor/bin:/vendor/xbin"
+#define	_PATH_DEFPATH	"/sbin:/system/sbin:/system/bin:/system/xbin:/vendor/bin:/vendor/xbin:/odm/bin"
 #define	_PATH_DEV	"/dev/"
 #define	_PATH_DEVNULL	"/dev/null"
 #define	_PATH_KLOG	"/proc/kmsg"

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -158,18 +158,23 @@ static soinfo* somain; // main process, always the one after libdl_info
 #if defined(__LP64__)
 static const char* const kSystemLibDir     = "/system/lib64";
 static const char* const kVendorLibDir     = "/vendor/lib64";
+static const char* const kOdmLibDir        = "/odm/lib64";
 static const char* const kAsanSystemLibDir = "/data/lib64";
 static const char* const kAsanVendorLibDir = "/data/vendor/lib64";
+static const char* const kAsanOdmLibDir    = "/data/odm/lib64";
 #else
 static const char* const kSystemLibDir     = "/system/lib";
 static const char* const kVendorLibDir     = "/vendor/lib";
+static const char* const kOdmLibDir        = "/odm/lib";
 static const char* const kAsanSystemLibDir = "/data/lib";
 static const char* const kAsanVendorLibDir = "/data/vendor/lib";
+static const char* const kAsanOdmLibDir    = "/data/odm/lib";
 #endif
 
 static const char* const kDefaultLdPaths[] = {
   kSystemLibDir,
   kVendorLibDir,
+  kOdmLibDir,
   nullptr
 };
 
@@ -178,6 +183,8 @@ static const char* const kAsanDefaultLdPaths[] = {
   kSystemLibDir,
   kAsanVendorLibDir,
   kVendorLibDir,
+  kAsanOdmLibDir,
+  kOdmLibDir,
   nullptr
 };
 


### PR DESCRIPTION
Some devices, like the Sony Loire series of devices (Xperia X) ship with an /odm partition containing firmware and binary blobs.

To add support for these devices upstream patches to the Bionic linker are required.